### PR TITLE
Add Pro screen stubs with ScrollView wrappers

### DIFF
--- a/client/src/screens/GifEditorPro.tsx
+++ b/client/src/screens/GifEditorPro.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ScrollView, View, Text, StyleSheet } from 'react-native';
+
+const GifEditorPro = () => {
+  return (
+    <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
+      <View>
+        <Text>Gif Editor Pro Screen</Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    padding: 16,
+  },
+});
+
+export default GifEditorPro;

--- a/client/src/screens/SocialMediaManagerPro.tsx
+++ b/client/src/screens/SocialMediaManagerPro.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ScrollView, View, Text, StyleSheet } from 'react-native';
+
+const SocialMediaManagerPro = () => {
+  return (
+    <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
+      <View>
+        <Text>Social Media Manager Pro Screen</Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    padding: 16,
+  },
+});
+
+export default SocialMediaManagerPro;

--- a/client/src/screens/WhatsAppMarketingPro.tsx
+++ b/client/src/screens/WhatsAppMarketingPro.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { ScrollView, View, Text, StyleSheet } from 'react-native';
+
+const WhatsAppMarketingPro = () => {
+  return (
+    <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
+      <View>
+        <Text>WhatsApp Marketing Pro Screen</Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+    padding: 16,
+  },
+});
+
+export default WhatsAppMarketingPro;


### PR DESCRIPTION
## Summary
- add WhatsAppMarketingPro, GifEditorPro, and SocialMediaManagerPro screens
- wrap each screen in a ScrollView with flex-grow content container styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a8102f46c8328a2a4faff8e0354d7